### PR TITLE
remove unused reqwest dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ homepage = "https://github.com/MidasLamb/axum-strangler"
 [dependencies]
 axum = { version = "0.5.13", features = ["ws"]}
 hyper = { version = "0.14.20", features = ["client", "http2", "tcp"] }
-reqwest = "0.11.11"
 tower-service = "0.3.2"
 tokio-tungstenite = "0.17.2"
 tokio = { version = "1.20.0", features = ["full"] }


### PR DESCRIPTION
I was investigating to use this library for migrating a mid-sized iron app to axum. 

While digging through source etc I found some issues, which I created as issue. 

Here a short PR for a simple additional thing I saw. 

( I'm planning on fixing the other issues too, piece by piece, depending on if you think these should be solved here or not )