### PR TITLE
tokio dependency is only needed for websockets or tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,24 @@ axum = { version = "0.5.13" }
 hyper = { version = "0.14.20", features = ["client", "http2", "tcp"] }
 tower-service = "0.3.2"
 tokio-tungstenite = { version = "0.17.2", optional = true }
-tokio = { version = "1.20.0", features = ["full"] }
+tokio = { version = "1.20.0", default-features = false, features = [
+  "macros",
+], optional = true }
 futures-util = { version = "0.3.21", features = ["futures-sink"] }
 tracing = "0.1.36"
 hyper-tls = "0.5.0"
 
 [dev-dependencies]
 reqwest = "0.11.11"
+tokio = { version = "1.20.0", default-features = false, features = [
+  "macros",
+  "rt-multi-thread",
+  "signal",
+] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
-websocket = ["dep:tokio-tungstenite", "axum/ws"]
+websocket = ["dep:tokio-tungstenite", "axum/ws", "dep:tokio"]
 
 
 [[example]]


### PR DESCRIPTION
On the road for easier integration with bigger apps we should only have the dependencies we need :) 